### PR TITLE
Kubernetes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  docker: circleci/docker@2.1.0
+  docker: circleci/docker@2.2.0
 executors:
   docker-publisher:
     docker:
@@ -10,7 +10,7 @@ jobs:
     docker:
       - image: cimg/go:1.20
         auth:
-          username: mydockerhub-user
+          username: twosharks
           password: $DOCKERHUB_PASSWORD
     steps:
       - checkout
@@ -28,7 +28,7 @@ jobs:
     docker:
       - image: cimg/go:1.20
         auth:
-          username: mydockerhub-user
+          username: twosharks
           password: $DOCKERHUB_PASSWORD
     steps:
       - checkout
@@ -67,4 +67,7 @@ workflows:
       - lint
       - test
       - build
+      - docker/publish:
+          image: twosharks/balanceproxy
+          tag: ${CIRCLE_SHA1:0:7},$CIRCLE_BRANCH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,20 @@
-FROM golang:1.20-alpine3.17 as go-builder
+FROM golang:1.20 as go-builder
 
-RUN apk add libpcap-dev build-base
+RUN apt-get update && apt-get install -y ca-certificates libcap-dev
 
 WORKDIR /app
 
 COPY . /app/
 
-RUN go build -o balanceProxy
+RUN make build
 
-RUN chmod +x balanceProxy
 
-FROM debian:bookworm-20230202-slim
+FROM ubuntu:20.04
 
-COPY --from=go-builder /app/balanceProxy /usr/local/bin/balanceProxy
+RUN apt-get update && apt-get install -y ca-certificates libcap-dev
 
-CMD ["balanceProxy", "server"]
+COPY --from=go-builder /app/ethBalanceProxy /usr/local/bin/ethBalanceProxy
 
-EXPOSE 8000
+RUN chmod +x /usr/local/bin/ethBalanceProxy
+
+EXPOSE 8080

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,17 @@ clean:
 dep:
 	go mod download
 
+kind\:init:
+	./scripts/kind-init.sh
+kind\:install:
+	./scripts/kind-install.sh
+kind\:test:
+	./scripts/kind-test.sh
+kind\:uninstall:
+	./scripts/kind-uninstall.sh
+kind\:teardown:
+	./scripts/kind-teardown.sh
+
 lint: fmt
 	./scripts/lint.sh
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,11 +1,9 @@
 # Operational Runbook
 
-# Testing, Developing & Debugging
-
 ## Grafana
 
 In the event of an issue or an alert, the grafana dashboard provides a snapshot of important metrics to help guide diagnosis
-and support healthy operations. 
+and support healthy operations.
 
 ## RPC Calls 
 ```
@@ -33,3 +31,23 @@ Directly calls `upstream.ethereum.Client{}.HealthCheck` against a single endpoin
 
 ## Unit Tests
 ```make test```
+
+## `kind` testing
+
+To support local testing in `kind`, a set of `kind:...` make targets are provided.
+
+### `make kind:init`
+
+Instantiates kind cluster and installs prometheus operator & crds
+
+### `make kind:install` / `make kind:uninstall`
+
+Installs/uninstalls the helm chart to/from a kind cluster created with `make kind:init`
+
+### `make kind:test`
+
+Forwards `kind` pod port 8080 to local 8080 and runs `scripts/debug/checkApi.sh` to exercise all the endpoints in the proxy
+
+### `make kind:teardown`
+
+Teardown `kind` cluster

--- a/helm/ethBalanceProxy/templates/deployment.yaml
+++ b/helm/ethBalanceProxy/templates/deployment.yaml
@@ -19,6 +19,8 @@ spec:
     spec:
       containers:
         - name: proxy
+          command: [ "ethBalanceProxy" ]
+          args: [ "server", "--upstreams", {{ .Values.proxy.endpoints | quote}} ]
           image: "{{ .Values.proxy.image.repository }}:{{ .Values.proxy.image.tag }}"
           imagePullPolicy: {{ .Values.proxy.image.pullPolicy }}
           ports:

--- a/helm/ethBalanceProxy/templates/deployment.yaml
+++ b/helm/ethBalanceProxy/templates/deployment.yaml
@@ -30,10 +30,10 @@ spec:
           livenessProbe:
             httpGet:
               path: /live
-              port: http
+              port: proxy
           readinessProbe:
             httpGet:
               path: /ready
-              port: http
+              port: proxy
           resources:
             {{- toYaml .Values.proxy.resources | nindent 12 }}

--- a/helm/ethBalanceProxy/templates/hpa.yaml
+++ b/helm/ethBalanceProxy/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.proxy.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: proxy
@@ -17,12 +17,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.proxy.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.proxy.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.proxy.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.proxy.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.proxy.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}

--- a/helm/ethBalanceProxy/values.yaml
+++ b/helm/ethBalanceProxy/values.yaml
@@ -9,7 +9,7 @@ proxy:
   image:
     repository: twosharks/balanceproxy
     pullPolicy: Always
-    tag: "k8s"
+    tag: "aba0912"
   ingress:
     enabled: false
     hosts:

--- a/helm/ethBalanceProxy/values.yaml
+++ b/helm/ethBalanceProxy/values.yaml
@@ -4,11 +4,12 @@ proxy:
     minReplicas: 1
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80
+  endpoints: "https://fittest-falling-smoke.discover.quiknode.pro/"
   host: "www.balanceproxy.com"
   image:
-    repository: twoshark/balanceproxy
-    pullPolicy: IfNotPresent
-    tag: "latest"
+    repository: twosharks/balanceproxy
+    pullPolicy: Always
+    tag: "k8s"
   ingress:
     enabled: false
     hosts:

--- a/scripts/kind-init.sh
+++ b/scripts/kind-init.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+clustername="balance-proxy-cluster"
+kind create cluster --name $clustername
+LATEST=$(curl -s https://api.github.com/repos/prometheus-operator/prometheus-operator/releases/latest | jq -cr .tag_name)
+curl -sL https://github.com/prometheus-operator/prometheus-operator/releases/download/"${LATEST}"/bundle.yaml | kubectl create -f -

--- a/scripts/kind-install.sh
+++ b/scripts/kind-install.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+helm del balance-proxy-test -n balance-proxy-test
+helm install balance-proxy-test helm/ethBalanceProxy/. -n balance-proxy-test --create-namespace
+

--- a/scripts/kind-teardown.sh
+++ b/scripts/kind-teardown.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 clustername="balance-proxy-cluster"
-kind destroy cluster --name $clustername
+kind delete cluster -n $clustername

--- a/scripts/kind-teardown.sh
+++ b/scripts/kind-teardown.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+clustername="balance-proxy-cluster"
+kind destroy cluster --name $clustername

--- a/scripts/kind-test.sh
+++ b/scripts/kind-test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "TBD"

--- a/scripts/kind-uninstall.sh
+++ b/scripts/kind-uninstall.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+helm del balance-proxy-test helm/ethBalanceProxy/. -n balance-proxy-test
+


### PR DESCRIPTION
# What

- Docker Hub publish in ci
- Fix helm chart and docker image so they run properly in Kubernetes

# Testing

# `kind` testing
- Local development setup allowing for an end to end test of the proxy running in kubernetes
- Kind has its limitations but can adequately serve this testing
- Add runbook entries to explain `kind:` make targets

## Output
```bash
$ make kind:init
./scripts/kind-init.sh
Creating cluster "balance-proxy-cluster" ...
 ✓ Ensuring node image (kindest/node:v1.25.3) 🖼
 ✓ Preparing nodes 📦
 ✓ Writing configuration 📜
 ✓ Starting control-plane 🕹️
 ✓ Installing CNI 🔌
 ✓ Installing StorageClass 💾
Set kubectl context to "kind-balance-proxy-cluster"
You can now use your cluster with:

kubectl cluster-info --context kind-balance-proxy-cluster

Have a nice day! 👋
customresourcedefinition.apiextensions.k8s.io/alertmanagerconfigs.monitoring.coreos.com created
customresourcedefinition.apiextensions.k8s.io/alertmanagers.monitoring.coreos.com created
customresourcedefinition.apiextensions.k8s.io/podmonitors.monitoring.coreos.com created
customresourcedefinition.apiextensions.k8s.io/probes.monitoring.coreos.com created
customresourcedefinition.apiextensions.k8s.io/prometheuses.monitoring.coreos.com created
customresourcedefinition.apiextensions.k8s.io/prometheusrules.monitoring.coreos.com created
customresourcedefinition.apiextensions.k8s.io/servicemonitors.monitoring.coreos.com created
customresourcedefinition.apiextensions.k8s.io/thanosrulers.monitoring.coreos.com created
clusterrolebinding.rbac.authorization.k8s.io/prometheus-operator created
clusterrole.rbac.authorization.k8s.io/prometheus-operator created
deployment.apps/prometheus-operator created
serviceaccount/prometheus-operator created
service/prometheus-operator created
$ make kind:install
./scripts/kind-install.sh
Error: uninstall: Release not loaded: balance-proxy-test: release: not found
NAME: balance-proxy-test
LAST DEPLOYED: Wed Feb 15 23:08:58 2023
NAMESPACE: balance-proxy-test
STATUS: deployed
REVISION: 1
$ k get po
NAME                                   READY   STATUS    RESTARTS   AGE
prometheus-operator-85498c86bb-rdj4b   0/1     Pending   0          0s
$ k get po --watch
NAME                                   READY   STATUS              RESTARTS   AGE
prometheus-operator-85498c86bb-rdj4b   0/1     ContainerCreating   0          10s
prometheus-operator-85498c86bb-rdj4b   1/1     Running             0          12s

$ kubie ns balance-proxy-test
$ k get po
NAME                     READY   STATUS    RESTARTS   AGE
proxy-7dd74b8fcf-wrjxr   0/1     Running   0          2m12s
$ k logs proxy-7dd74b8fcf-wrjxr --tail 10

   ____    __
  / __/___/ /  ___
 / _// __/ _ \/ _ \
/___/\__/_//_/\___/ v4.10.0
High performance, minimalist Go web framework
https://echo.labstack.com
____________________________________O/_______
                                    O\
⇨ http server started on [::]:8080
$ k get po
NAME                     READY   STATUS    RESTARTS   AGE
proxy-7dd74b8fcf-wrjxr   0/1     Running   0          2m41s

$ make kind:test
./scripts/kind-test.sh
Wait for forwarding..

Handling connection for 8080
server rootHandling connection for 8080
{"balance":"1040010508879531809"}

Handling connection for 8080
{"balance":"1505696375795330922"}

Handling connection for 8080
# HELP echo_request_duration_seconds The HTTP request latencies in seconds.
# TYPE echo_request_duration_seconds histogram
...
# HELP upstreams_healthy currently healthy upstream endpoints
# TYPE upstreams_healthy gauge
upstreams_healthy 1

Handling connection for 8080
live
Handling connection for 8080
ready⏎
```